### PR TITLE
Add Linode per size/region breakdown, reliability improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ akamai-linode events audit --follow
 ```
 
 ### Objects utilization
+
 ```
 akamai-linode utilization --include-stackscripts --follow
 ```
@@ -36,9 +37,28 @@ In follow mode, it will print the different counters by object type from your ac
 Example:
 ```json
 {
-    "time": "2024-10-03T18:40:25.164050+00:00", 
+    "time": "2025-08-11T23:15:44.531463+00:00", 
     "account": "My company name", 
-    "linode": 25, 
+    "linode": 3605, 
+    "linode_details": {
+        "by_region": {
+        "in-maa": 394,
+        "se-sto": 913,
+        "de-fra-2": 694,
+        "us-iad": 226,
+        "jp-osa": 263,
+        "br-gru": 741,
+        "sg-sin-2": 561,
+        "us-lax": 208
+        },
+        "by_type": {
+        "g6-standard-4": 468,
+        "g6-standard-8": 266,
+        "g6-standard-2": 546,
+        "g6-nanode-1": 2474,
+        "g6-standard-1": 246
+        }
+    },
     "image": {
         "private_count": 9,
         "private_size": 52438,

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ Setup the `.edgerc` file as described [here](#authentication)
 akamai-linode events audit --follow
 ```
 
-### Objects utilization
+### Entities utilization
 
 ```
 akamai-linode utilization --include-stackscripts --follow
 ```
 
-In follow mode, it will print the different counters by object type from your account.  
-Example:
+Will print the different counters by object type from your account.  
+With the `--follow` argument, the command will refresh every 5 minutes until you SIG_INT / press Control-Break.
+
+Output example:
 ```json
 {
     "time": "2025-08-11T23:15:44.531463+00:00", 
@@ -42,21 +44,21 @@ Example:
     "linode": 3605, 
     "linode_details": {
         "by_region": {
-        "in-maa": 394,
-        "se-sto": 913,
-        "de-fra-2": 694,
-        "us-iad": 226,
-        "jp-osa": 263,
-        "br-gru": 741,
-        "sg-sin-2": 561,
-        "us-lax": 208
+            "in-maa": 394,
+            "se-sto": 913,
+            "de-fra-2": 694,
+            "us-iad": 226,
+            "jp-osa": 263,
+            "br-gru": 741,
+            "sg-sin-2": 561,
+            "us-lax": 208
         },
         "by_type": {
-        "g6-standard-4": 468,
-        "g6-standard-8": 266,
-        "g6-standard-2": 546,
-        "g6-nanode-1": 2474,
-        "g6-standard-1": 246
+            "g6-standard-4": 468,
+            "g6-standard-8": 266,
+            "g6-standard-2": 546,
+            "g6-nanode-1": 2474,
+            "g6-standard-1": 246
         }
     },
     "image": {
@@ -78,4 +80,4 @@ Example:
 
 Note the last counter, `stackscript` will be reported only when using `--include-stackscripts` argument is added to the command line.
 
-To send these events into your SIEM, please checkout [Akamai Unified Log Streamer](https://github.com/akamai/uls)
+To send these events into your SIEM i.e. Splunk, please checkout [Akamai Unified Log Streamer](https://github.com/akamai/uls)

--- a/bin/modules/utilization.py
+++ b/bin/modules/utilization.py
@@ -121,7 +121,7 @@ class linode_count(object):
         total_pages = pages[0].get('pages', 1)
         if total_pages > 1:
             for page in range(2, total_pages):
-                pages.append(self.api_client('/images', params={'page': page}))
+                pages.append(self.api_client.get('/images', params={'page': page}))
         for p in pages:
             for i in p.get('data', []):
                 if i.get('is_public') is False and i.get('expiry') is None:
@@ -164,6 +164,11 @@ class linode_count(object):
 
 
 def stats_one(ln_edgerc, stackscripts: bool = False):
+    api_token = ln_edgerc.get('linode_token')
+    if not api_token:
+        aka_log.log.fatal("API Token not found or empty in EdgeRC file.")
+        exit(1)
+
     linode_api_headers = {
         'Authorization': 'Bearer ' + api_token,
     }

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.32
 pyasn1>=0.6.1
+pytz


### PR DESCRIPTION
Improvement focused on the `--utilization` command line:

- Add a new `linode_details` key with two sub-keys, `by_region` and `by_type`
- Improved handling in case of non-200 API response
- Updated documentation to reflect the update JSON schema